### PR TITLE
Adds an onChange callback

### DIFF
--- a/vunit.js
+++ b/vunit.js
@@ -26,7 +26,10 @@
             viewportObserverInterval: opts.viewportObserverInterval || 100,
 
             // The CSS rules to be vUnit'd
-            CSSMap: opts.CSSMap || null
+            CSSMap: opts.CSSMap || null,
+            
+            // called on change
+            onChange: opts.onChange || null
         };
 
         // Stores the viewport dimensions so the observer can check against it and update it.
@@ -70,6 +73,10 @@
                         var CSSRules = createCSSRules();
                         appendCSSRulesToStylesheet(CSSRules, stylesheet);
                         appendStylesheetOnHead(stylesheet);
+                        
+                        if (vunit.options.onChange) {
+                            vunit.options.onChange(vunit.viewportSize);
+                        }
                     }
 
                     return viewportObserver;


### PR DESCRIPTION
Proposing an optional callback (`onChange`) that gets called when vunit detects viewport changes.
the callback gets a parameter, the object of viewport dims. ex: `{width: 1174, height: 993}`.

if you're doing expensive calls here, may want to use <https://remysharp.com/2010/07/21/throttling-function-calls>